### PR TITLE
Fix diponbeat

### DIFF
--- a/TkPixels/AfterEffects.py
+++ b/TkPixels/AfterEffects.py
@@ -66,7 +66,7 @@ class DipOnBeat(AfterEffect):
         brightness = max(0, brightness)
 
         # dip the brightness of the pixels
-        pixels = np.uint8(pixels * brightness)
+        pixels = np.int64(pixels * brightness)
 
         return pixels
     

--- a/readme.md
+++ b/readme.md
@@ -26,9 +26,14 @@ sudo pip install numpy
 ```
 
 # Run
+To start both input and the led show, run:
+```bash
+sudo /home/tuanke/Programming/TkPixels/start_project.sh
+```
+
 To start the input, run:
 ```bash
-source myenv/activate/bin
+source myenv/bin/activate
 cd Programming/TkPixels
 python start_input.py
 ```


### PR DESCRIPTION
Problem: dipOnBeat AfterEffect caused only blue lights to appear.

Solution: changed data type of dipOnBeat output from unit8 to int64.